### PR TITLE
Fix set_timeout call

### DIFF
--- a/components/dallasng/dallasng_component.cpp
+++ b/components/dallasng/dallasng_component.cpp
@@ -102,7 +102,7 @@ namespace esphome
 
       for (auto *sensor : sensors_)
       {
-        set_timeout(sensor->get_address_name(), sensor->millis_to_wait_for_conversion(), [this, sensor]
+        set_timeout(sensor->millis_to_wait_for_conversion(), [this, sensor]
                     {
           float value;
           if (!sensor->try_get_temperature_c(&value)) {


### PR DESCRIPTION
std::string as first parameter - to be deprecated in 2026.7.0