### PR TITLE
fixing a off-by-one bug

### DIFF
--- a/components/dallasng/dallasng_component.cpp
+++ b/components/dallasng/dallasng_component.cpp
@@ -27,7 +27,7 @@ namespace esphome
         if (sensor->get_index().has_value())
         {
           auto index = *sensor->get_index();
-          if (index > found_sensors_.size())
+          if (index >= found_sensors_.size())
           {
             ESP_LOGW(TAG, "Index %d higher than the number of sensors (%d)", index, found_sensors_.size());
             status_set_error();


### PR DESCRIPTION
This fixes the crash that happens when index=0 and no sensor is found.