### PR TITLE
fixing a deprecation warning

### DIFF
--- a/components/dallasng/dallasng_component.cpp
+++ b/components/dallasng/dallasng_component.cpp
@@ -102,7 +102,7 @@ namespace esphome
 
       for (auto *sensor : sensors_)
       {
-        set_timeout(sensor->get_address_name(), sensor->millis_to_wait_for_conversion(), [this, sensor]
+        set_timeout(sensor->get_address_name().c_str(), sensor->millis_to_wait_for_conversion(), [this, sensor]
                     {
           float value;
           if (!sensor->try_get_temperature_c(&value)) {


### PR DESCRIPTION
This fixes:

src/esphome/components/dallasng/dallasng_component.cpp: In member function 'virtual void esphome::dallasng::DallasNgComponent::update()':
src/esphome/components/dallasng/dallasng_component.cpp:105:20: warning: 'void esphome::Component::set_timeout(const std::string&, uint32_t, std::function<void()>&&)' is deprecated: Use const char* or uint32_t overload instead. Removed in 2026.7.0 [-Wdeprecated-declarations]
